### PR TITLE
Set fail-fast to false for github action strategy

### DIFF
--- a/.github/workflows/tests-and-docs.yml
+++ b/.github/workflows/tests-and-docs.yml
@@ -9,6 +9,7 @@ jobs:
   Install-Test-Doc-Braindecode:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         skorch_version: ['main', 'stable']
     defaults:


### PR DESCRIPTION
This will stop other jobs from being cancelled when one fails